### PR TITLE
Moving footnotes when refactoring notes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,22 @@
+# TODO Map
+
+- ~~Write pseudo code~~
+- ~~Create a walking skeleton~~
+    - Call a method with the right 3 arguments
+        - understand how to get the full active buffer text
+          - Found something at: https://txt.binnyva.com/2021/08/get-current-file-content-in-obsidian/, reading HDD directly... not sure this is the best wy
+          - Another way could be to get all the lines from the Editor, and then aggregate them
+          - We are not really looking for all the text, but rather for the lines defining the footnotes
+          - Do something like the noteRemainder in NRDoc
+    - ~~implement the method to return the input~~
+    - should I update the note content ? or should I call this after the templating?
+        - noteContent: used for all refactors, better tested, 
+            - BUT: THIS CONTENT IS USED TO DO A REPLACE IN ORIGINAL NOTE!
+        - after templating: safer, no conflict
+            - but: needs new tests
+            - BUT: NEEDS TO BE CALLED IN ALL REFACTORS
+    - ~~add a 'dumb' test (no footnote ref)~~
+    - ~~build the plugin~~
+    - ~~create a test vault~~
+    - ~~test it on a test vault~~
+- Test drive the different cases

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -133,8 +133,15 @@ export default class NRDoc {
 
 
     appendFootnotes(originalNote:string, note:string, completeOriginalNote:string[]): string {
-      if (note.includes("[^1]"))
-        return note + "\n" + completeOriginalNote[completeOriginalNote.length - 1];
+      var match = /\[\^[1-9]\]/.exec(note)
+      if (match === null)
+        return note;
+
+      for (let line of completeOriginalNote) {
+        if (line.startsWith(match[0] + ":")) {
+          return note + "\n" + line;
+        }
+      }
       return note;
     }
 

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -79,6 +79,14 @@ export default class NRDoc {
       return trimmedContent.split('\n');
     }
 
+    fullNoteContent(doc:Editor): string[] {
+      const startPosition = doc.offsetToPos(0);
+      const endPosition = doc.offsetToPos(doc.getValue().length);
+      const content = doc.getRange(startPosition, endPosition);
+      const trimmedContent = content.trim();
+      return trimmedContent.split('\n');
+    }
+
     contentSplitByHeading(doc:Editor, headingLevel: number): string[][] {
       const content = doc.getValue().split('\n');
       const parentHeading = new Array(headingLevel).join('#') + ' ';
@@ -122,4 +130,12 @@ export default class NRDoc {
       }
       return contentArr.join('\n').trim();
     }
+
+
+    appendFootnotes(originalNote:string, note:string, completeOriginalNote:string[]): string {
+      if (note.includes("[^1]"))
+        return note + "\n" + completeOriginalNote[completeOriginalNote.length - 1];
+      return note;
+    }
+
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -175,6 +175,10 @@ export default class NoteRefactor extends Plugin {
       const newNoteLink = await this.NRDoc.markdownLink(filePath);
       note = this.NRDoc.templatedContent(note, this.settings.refactoredNoteTemplate, mdView.file.basename, link, fileName, newNoteLink, '', note);
     }
+
+    let completeOriginalNote = this.NRDoc.fullNoteContent(mdView.editor);
+    note = this.NRDoc.appendFootnotes(originalNote, note, completeOriginalNote);
+
     await this.obsFile.createOrAppendFile(fileName, note);
     await this.NRDoc.replaceContent(fileName, filePath, doc, mdView.file, note, originalNote, mode);
     if(!isMultiple && this.settings.openNewNote) {

--- a/tests/doc.test.ts
+++ b/tests/doc.test.ts
@@ -153,6 +153,65 @@ describe("Note content - First Line as File Name, first line as heading (modifie
 
 });
 
+describe("Append Footnotes", () => {
+
+    it("Does not change anything if the note does not contain any footnotes", () => {
+        const originalNote = ["some markdown"];
+        const note = originalNote;
+        const completeOriginalNote = [
+            "# title",
+            "",
+            ...originalNote,
+            "",
+            "## sub section"
+        ];
+        const noteWithFootnotes = doc.appendFootnotes(originalNote.join("\n"), note.join("\n"), completeOriginalNote);
+       assert.equal(noteWithFootnotes, note.join("\n"));
+    });
+
+    it("does not change if footnotes in full original note, but not in extracted section", () => {
+        const originalNote = ["some markdown"];
+        const note = originalNote;
+        const completeOriginalNote = [
+            "# title",
+            "",
+            ...originalNote,
+            "",
+            "## sub section",
+            "[^1]: my footnotes"
+        ];
+        const noteWithFootnotes = doc.appendFootnotes(originalNote.join("\n"), note.join("\n"), completeOriginalNote);
+        assert.equal(noteWithFootnotes, note.join("\n"));
+     });
+
+    it("copies one referenced footnote from the last line of full content", () => {
+        const originalNote = ["some markdown[^1]"];
+        const note = originalNote;
+        const completeOriginalNote = [
+            "# title",
+            "",
+            ...originalNote,
+            "",
+            "## sub section",
+            "[^1]: my footnotes"
+        ];
+        const noteWithFootnotes = doc.appendFootnotes(originalNote.join("\n"), note.join("\n"), completeOriginalNote);
+        assert.equal(noteWithFootnotes, "some markdown[^1]\n[^1]: my footnotes");
+     });
+
+    /*
+    copies 1 footnotes from original
+    does not copy all footnotes
+    copies 2 or more footnotes from original
+    only copies each footnote once max
+    edge cases around footnotes markdown declaration syntax (https://www.markdownguide.org/extended-syntax/#footnotes)
+        footnote declared with words 
+        multiline footnotes
+        footnote inside the rest of the doc
+        multiline footnote inside the rest of the doc
+    */
+});
+
 
 async function loadTestFile(): Promise<string> {
     return await fs.readFile(newLocal, 'utf8');

--- a/tests/doc.test.ts
+++ b/tests/doc.test.ts
@@ -199,6 +199,54 @@ describe("Append Footnotes", () => {
         assert.equal(noteWithFootnotes, "some markdown[^1]\n[^1]: my footnotes");
      });
 
+     it("captures footnotes, whatever the tag number", () => {
+        const originalNote = ["some markdown[^2]"];
+        const note = originalNote;
+        const completeOriginalNote = [
+            "# title",
+            "",
+            ...originalNote,
+            "",
+            "## sub section",
+            "[^1]: footnote 1",
+            "[^2]: footnote 2"
+        ];
+        const noteWithFootnotes = doc.appendFootnotes(originalNote.join("\n"), note.join("\n"), completeOriginalNote);
+        assert.equal(noteWithFootnotes, "some markdown[^2]\n[^2]: footnote 2");
+     });
+
+     it("captures the right footnote depending on the tag", () => {
+        const originalNote = ["some markdown[^1]"];
+        const note = originalNote;
+        const completeOriginalNote = [
+            "# title",
+            "",
+            ...originalNote,
+            "",
+            "## sub section",
+            "[^1]: footnote 1",
+            "[^2]: footnote 2"
+        ];
+        const noteWithFootnotes = doc.appendFootnotes(originalNote.join("\n"), note.join("\n"), completeOriginalNote);
+        assert.equal(noteWithFootnotes, "some markdown[^1]\n[^1]: footnote 1");
+     });
+
+     it("ignores footnotes which don't have a declaration", () => {
+        const originalNote = ["some markdown[^7]"];
+        const note = originalNote;
+        const completeOriginalNote = [
+            "# title",
+            "",
+            ...originalNote,
+            "",
+            "## sub section",
+            "[^1]: footnote 1",
+            "[^2]: footnote 2"
+        ];
+        const noteWithFootnotes = doc.appendFootnotes(originalNote.join("\n"), note.join("\n"), completeOriginalNote);
+        assert.equal(noteWithFootnotes, "some markdown[^7]");
+     });
+
     /*
     copies 1 footnotes from original
     does not copy all footnotes


### PR DESCRIPTION
### Current status

The feature is far from complete, plenty of edge cases remain to deal with. For the moment, it deals with:

- "extract using first line as title" refactoring
- A single footnote
- Footnotes tags that are single digits

### Design overview

- Add new method `NRDoc.appendFootnotes(originalNote:string, note:string, completeOriginalNote:string[]): string` that appends footnotes to the extracted note
- The method is called from `main.ts` after templating
- I added tests around the `appendFootnotes`
